### PR TITLE
Add dark mode (#10) and fix a few CSS bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# editors
 .vscode
+.idea
+
+# macOS
+.DS_Store

--- a/web/src/components/Structure/Footer.tsx
+++ b/web/src/components/Structure/Footer.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 
 interface FooterProps {}
 const Footer: FC<FooterProps> = ({}) => (
-    <footer className="footer bg-white shadow py-4 px-4 bottom-0">
+    <footer className="footer bg-white py-4 px-4 bottom-0">
         <section className="bg-white py-8 w-full">
             <div className="container mx-auto px-8">
                 <div className="table w-full">

--- a/web/src/components/Structure/Footer.tsx
+++ b/web/src/components/Structure/Footer.tsx
@@ -2,8 +2,8 @@ import { FC } from "react";
 
 interface FooterProps {}
 const Footer: FC<FooterProps> = ({}) => (
-    <footer className="footer bg-white py-4 px-4 bottom-0">
-        <section className="bg-white py-8 w-full">
+    <footer className="footer py-4 px-4 bottom-0">
+        <section className="py-8 w-full">
             <div className="container mx-auto px-8">
                 <div className="table w-full">
                     <div className="block sm:table-cell">

--- a/web/src/components/Structure/Layout.tsx
+++ b/web/src/components/Structure/Layout.tsx
@@ -72,7 +72,7 @@ const Layout: FC<LayoutProps> = ({ children, ...props }: LayoutProps) => {
     return (
         <div className="min-h-screen" {...props}>
             <div className="flex flex-row min-h-screen text-gray-800">
-                <aside className="sidebar w-64 shadow transform -translate-x-full md:translate-x-0 transition-transform duration-150 ease-in z-10">
+                <aside className="sidebar w-64 shadow transform -translate-x-full md:translate-x-0 transition-transform hidden md:block duration-150 ease-in z-10 bg-contrast-0">
                     <div className="sidebar-header flex items-center justify-center py-4">
                         <div className="inline-flex">
                             <a
@@ -168,7 +168,7 @@ const Layout: FC<LayoutProps> = ({ children, ...props }: LayoutProps) => {
                 </aside>
 				<div className="min-h-screen w-full flex flex-col z-0">
 					<div className="px-12 h-full">
-						<div className="sticky py-8 top-0 bg-white">
+						<div className="py-8 top-0 bg-white">
 							<header className="header bg-white">
 								<div className="header-content flex items-center flex-row">
 									<div className="hidden md:flex relative w-full">

--- a/web/src/components/Structure/Layout.tsx
+++ b/web/src/components/Structure/Layout.tsx
@@ -72,28 +72,30 @@ const Layout: FC<LayoutProps> = ({ children, ...props }: LayoutProps) => {
 
     return (
     	<DarkModeCtx.Provider value={{ dark, setDark }}>
-			<div className="min-h-screen" {...props}>
-				<div className="flex flex-row min-h-screen text-gray-800">
+			<div className="min-h-screen bg-contrast-300 text-contrast-700" {...props}>
+				<div className="flex flex-row min-h-screen">
 					<SideBar authenticated={authenticated} user={user}/>
 
 					<div className="min-h-screen w-full flex flex-col z-0">
 						<div className="px-12 h-full">
-							<div className="py-8 top-0 bg-white">
-								<header className="header bg-white">
+							<div className="py-8 top-0">
+								<header className="header">
 									<div className="header-content flex items-center flex-row">
-										<div className="hidden md:flex relative w-full">
+										<div className="hidden md:flex relative w-full text-contrast-700 hover:text-contrast-600">
 											<button
 												id="search"
 												name="search"
 												value={searchQuery}
-												className="group border px-3 rounded-lg leading-6 flex items-center space-x-2 sm:space-x-4 hover:text-gray-600 transition-colors duration-200 w-full py-2"
-												// className="text-sm sm:text-base placeholder-gray-500 pl-10 pr-4 w-full rounded-lg border border-gray-300 w-full h-10 focus:outline-none focus:border-green-500"
+												className="group border border-contrast-400 px-3 rounded-lg leading-6
+													flex items-center space-x-2 sm:space-x-4
+													transition-colors duration-200 w-full py-2"
 												placeholder="Search..."
 												onClick={openModal}
 											>
 												<AiOutlineSearch />
 												<span>Search...</span>
-												<span className="ml-auto text-gray-400 text-sm leading-5 py-0.5 px-1.5 border border-gray-300 rounded-md">
+												<span className="ml-auto text-sm leading-5 py-0.5 px-1.5
+													border border-contrast-400 rounded-md">
                                         Ctrl + K
                                     </span>
 											</button>

--- a/web/src/components/Structure/Layout.tsx
+++ b/web/src/components/Structure/Layout.tsx
@@ -72,7 +72,7 @@ const Layout: FC<LayoutProps> = ({ children, ...props }: LayoutProps) => {
     return (
         <div className="min-h-screen" {...props}>
             <div className="flex flex-row min-h-screen text-gray-800">
-                <aside className="sidebar w-64 md:shadow transform -translate-x-full md:translate-x-0 transition-transform duration-150 ease-in">
+                <aside className="sidebar w-64 shadow transform -translate-x-full md:translate-x-0 transition-transform duration-150 ease-in z-10">
                     <div className="sidebar-header flex items-center justify-center py-4">
                         <div className="inline-flex">
                             <a
@@ -88,7 +88,7 @@ const Layout: FC<LayoutProps> = ({ children, ...props }: LayoutProps) => {
                             </a>
                         </div>
                     </div>
-                    <div className="sidebar-content px-4 py-6 sticky top-0">
+                    <nav className="sidebar-content px-4 py-6 sticky top-0">
                         <ul className="flex flex-col w-full">
                             <li className="my-px">
                                 <span className="flex font-medium text-sm text-gray-500 px-4 my-4 uppercase">
@@ -164,53 +164,61 @@ const Layout: FC<LayoutProps> = ({ children, ...props }: LayoutProps) => {
                                 </>
                             ) : null}
                         </ul>
-                    </div>
+                    </nav>
                 </aside>
-                <main className="main flex flex-col flex-grow -ml-64 md:ml-0 transition-all duration-150 ease-in">
-                    <header className="sticky header bg-white shadow py-4 px-4 top-0 z-10">
-                        <div className="header-content flex items-center flex-row">
-                            <div className="hidden md:flex relative w-3/4">
-                                <button
-                                    id="search"
-                                    name="search"
-                                    value={searchQuery}
-                                    className="group border px-3 rounded-lg leading-6 flex items-center space-x-2 sm:space-x-4 hover:text-gray-600 transition-colors duration-200 w-full py-2"
-                                    // className="text-sm sm:text-base placeholder-gray-500 pl-10 pr-4 w-full rounded-lg border border-gray-300 w-full h-10 focus:outline-none focus:border-green-500"
-                                    placeholder="Search..."
-                                    onClick={openModal}
-                                >
-                                    <AiOutlineSearch />
-                                    <span>Search...</span>
-                                    <span className="ml-auto text-gray-400 text-sm leading-5 py-0.5 px-1.5 border border-gray-300 rounded-md">
+				<div className="min-h-screen w-full flex flex-col z-0">
+					<div className="px-12 h-full">
+						<div className="sticky py-8 top-0 bg-white">
+							<header className="header bg-white">
+								<div className="header-content flex items-center flex-row">
+									<div className="hidden md:flex relative w-full">
+										<button
+											id="search"
+											name="search"
+											value={searchQuery}
+											className="group border px-3 rounded-lg leading-6 flex items-center space-x-2 sm:space-x-4 hover:text-gray-600 transition-colors duration-200 w-full py-2"
+											// className="text-sm sm:text-base placeholder-gray-500 pl-10 pr-4 w-full rounded-lg border border-gray-300 w-full h-10 focus:outline-none focus:border-green-500"
+											placeholder="Search..."
+											onClick={openModal}
+										>
+											<AiOutlineSearch />
+											<span>Search...</span>
+											<span className="ml-auto text-gray-400 text-sm leading-5 py-0.5 px-1.5 border border-gray-300 rounded-md">
                                         Ctrl + K
                                     </span>
-                                </button>
-                            </div>
-                            {user ? (
-                                <LoginButton
-                                    authenticated={authenticated}
-                                    user={user}
-                                />
-                            ) : null}
-                        </div>
-                    </header>
-                    <TopSearchBar
-                        searchResults={searchResults}
-                        searchQuery={searchQuery}
-                        modalIsOpen={modalIsOpen}
-                        closeModal={closeModal}
-                        clearSearchQuery={clearSearchQuery}
-                        handleSearchChange={handleSearchChange}
-                    />
-                    <div className="container mx-auto mt-12 mb-24 pb-5 h-full">
-                        {/* Page Contents here */}
-                        {children}
-                    </div>
-                    <Footer />
-                </main>
-            </div>
-        </div>
-    );
+										</button>
+									</div>
+									{user ? (
+										<LoginButton
+											authenticated={authenticated}
+											user={user}
+										/>
+									) : null}
+								</div>
+							</header>
+							<TopSearchBar
+								searchResults={searchResults}
+								searchQuery={searchQuery}
+								modalIsOpen={modalIsOpen}
+								closeModal={closeModal}
+								clearSearchQuery={clearSearchQuery}
+								handleSearchChange={handleSearchChange}
+							/>
+						</div>
+
+						<main className="h-full main flex flex-col flex-grow transition-all duration-150 ease-in">
+							<div className="container mb-24 pb-5 h-full">
+								{/* Page Contents here */}
+								{children}
+							</div>
+						</main>
+					</div>
+
+					<Footer />
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default Layout;

--- a/web/src/components/Structure/Layout.tsx
+++ b/web/src/components/Structure/Layout.tsx
@@ -1,28 +1,14 @@
 import React, { FC, useState, useEffect } from "react";
 import { ReactNode } from "react";
-import Image from "next/image";
-import MenuItem from "./MenuItem";
-import {
-    FiBookOpen,
-    FiArchive,
-    FiUser,
-    FiLogOut,
-    FiLogIn,
-    FiHome,
-    FiUsers,
-} from "react-icons/fi";
-import {
-    AiOutlinePlusCircle,
-    AiOutlineMail,
-    AiOutlineSearch,
-} from "react-icons/ai";
 import LoginButton from "./LoginButton";
 import { User } from "../../types";
-import { MdLibraryBooks } from "react-icons/md";
 import Footer from "./Footer";
 import Modal from "react-modal";
 import TopSearchBar from "./TopSearchBar";
 import { useHotkeys } from "react-hotkeys-hook";
+import { SideBar } from "./SideBar";
+import { DarkModeCtx } from "../../hooks/use-dark-mode";
+import { AiOutlineSearch } from "react-icons/ai";
 
 interface LayoutProps {
     children: ReactNode;
@@ -34,7 +20,22 @@ const Layout: FC<LayoutProps> = ({ children, ...props }: LayoutProps) => {
     const [searchResults, setSearchResults] = useState<[]>([]);
     const [searchQuery, setSearchQuery] = useState<string>("");
 
-    // Modal Logic
+    // TODO: Save theme preference in the cookies (or somewhere else) so that
+	// the server can render it.
+	const [dark, setDark] = useState(false);
+
+	useEffect(() => {
+		setDark(localStorage.getItem("dark") === "true");
+	}, []);
+
+	useEffect(() => {
+		if (dark) document.documentElement.classList.add("dark");
+		else document.documentElement.classList.remove("dark");
+
+		localStorage.setItem("dark", dark.toString());
+	}, [dark]);
+
+	// Modal Logic
     const [modalIsOpen, setIsOpen] = useState<boolean>(false);
     const openModal = () => setIsOpen(true);
     const closeModal = () => setIsOpen(false);
@@ -70,154 +71,64 @@ const Layout: FC<LayoutProps> = ({ children, ...props }: LayoutProps) => {
     const getUser = async () => fetch("/api/user/@me");
 
     return (
-        <div className="min-h-screen" {...props}>
-            <div className="flex flex-row min-h-screen text-gray-800">
-                <aside className="sidebar w-64 shadow transform -translate-x-full md:translate-x-0 transition-transform hidden md:block duration-150 ease-in z-10 bg-contrast-0">
-                    <div className="sidebar-header flex items-center justify-center py-4">
-                        <div className="inline-flex">
-                            <a
-                                href="/"
-                                className="inline-flex flex-row items-center"
-                            >
-                                <Image
-                                    src="/book.png"
-                                    alt="TMW"
-                                    width={40}
-                                    height={40}
-                                />
-                            </a>
-                        </div>
-                    </div>
-                    <nav className="sidebar-content px-4 py-6 sticky top-0">
-                        <ul className="flex flex-col w-full">
-                            <li className="my-px">
-                                <span className="flex font-medium text-sm text-gray-500 px-4 my-4 uppercase">
-                                    Wiki
-                                </span>
-                            </li>
-                            <MenuItem name="Home" href="/" icon={<FiHome />} />
-                            <MenuItem
-                                name="Articles"
-                                href="/articles"
-                                icon={<FiBookOpen />}
-                            />
-                            <MenuItem
-                                name="New Article"
-                                href="/article/new"
-                                icon={<AiOutlinePlusCircle />}
-                            />
-                            <MenuItem
-                                name="Archive"
-                                href="/archive"
-                                icon={<FiArchive />}
-                            />
+    	<DarkModeCtx.Provider value={{ dark, setDark }}>
+			<div className="min-h-screen" {...props}>
+				<div className="flex flex-row min-h-screen text-gray-800">
+					<SideBar authenticated={authenticated} user={user}/>
 
-                            <li className="my-px">
-                                <span className="flex font-medium text-sm text-gray-500 px-4 my-4 uppercase">
-                                    Account
-                                </span>
-                            </li>
-
-                            {authenticated ? (
-                                <>
-                                    <MenuItem
-                                        name="Profile"
-                                        href="/profile/@me"
-                                        icon={<FiUser />}
-                                    />
-                                    <MenuItem
-                                        name="Logout"
-                                        href="/api/auth/logout"
-                                        icon={<FiLogOut color="red" />}
-                                    />
-                                </>
-                            ) : (
-                                <MenuItem
-                                    name="Login"
-                                    href="/api/auth/login"
-                                    icon={<FiLogIn color="green" />}
-                                />
-                            )}
-
-                            {user && user?.rank > 4 ? (
-                                <>
-                                    <li className="my-px">
-                                        <span className="flex font-medium text-sm text-gray-500 px-4 my-4 uppercase">
-                                            Admin
-                                        </span>
-                                    </li>
-                                    <MenuItem
-                                        name="Articles"
-                                        href="/admin/articles"
-                                        icon={<MdLibraryBooks />}
-                                    />
-                                    <MenuItem
-                                        name="Users"
-                                        href="/admin/users"
-                                        icon={<FiUsers />}
-                                    />
-                                    <MenuItem
-                                        name="Message Discord"
-                                        href="/admin/message"
-                                        icon={<AiOutlineMail />}
-                                    />
-                                </>
-                            ) : null}
-                        </ul>
-                    </nav>
-                </aside>
-				<div className="min-h-screen w-full flex flex-col z-0">
-					<div className="px-12 h-full">
-						<div className="py-8 top-0 bg-white">
-							<header className="header bg-white">
-								<div className="header-content flex items-center flex-row">
-									<div className="hidden md:flex relative w-full">
-										<button
-											id="search"
-											name="search"
-											value={searchQuery}
-											className="group border px-3 rounded-lg leading-6 flex items-center space-x-2 sm:space-x-4 hover:text-gray-600 transition-colors duration-200 w-full py-2"
-											// className="text-sm sm:text-base placeholder-gray-500 pl-10 pr-4 w-full rounded-lg border border-gray-300 w-full h-10 focus:outline-none focus:border-green-500"
-											placeholder="Search..."
-											onClick={openModal}
-										>
-											<AiOutlineSearch />
-											<span>Search...</span>
-											<span className="ml-auto text-gray-400 text-sm leading-5 py-0.5 px-1.5 border border-gray-300 rounded-md">
+					<div className="min-h-screen w-full flex flex-col z-0">
+						<div className="px-12 h-full">
+							<div className="py-8 top-0 bg-white">
+								<header className="header bg-white">
+									<div className="header-content flex items-center flex-row">
+										<div className="hidden md:flex relative w-full">
+											<button
+												id="search"
+												name="search"
+												value={searchQuery}
+												className="group border px-3 rounded-lg leading-6 flex items-center space-x-2 sm:space-x-4 hover:text-gray-600 transition-colors duration-200 w-full py-2"
+												// className="text-sm sm:text-base placeholder-gray-500 pl-10 pr-4 w-full rounded-lg border border-gray-300 w-full h-10 focus:outline-none focus:border-green-500"
+												placeholder="Search..."
+												onClick={openModal}
+											>
+												<AiOutlineSearch />
+												<span>Search...</span>
+												<span className="ml-auto text-gray-400 text-sm leading-5 py-0.5 px-1.5 border border-gray-300 rounded-md">
                                         Ctrl + K
                                     </span>
-										</button>
+											</button>
+										</div>
+										{user ? (
+											<LoginButton
+												authenticated={authenticated}
+												user={user}
+											/>
+										) : null}
 									</div>
-									{user ? (
-										<LoginButton
-											authenticated={authenticated}
-											user={user}
-										/>
-									) : null}
+								</header>
+								<TopSearchBar
+									searchResults={searchResults}
+									searchQuery={searchQuery}
+									modalIsOpen={modalIsOpen}
+									closeModal={closeModal}
+									clearSearchQuery={clearSearchQuery}
+									handleSearchChange={handleSearchChange}
+								/>
+							</div>
+
+							<main className="h-full main flex flex-col flex-grow transition-all duration-150 ease-in">
+								<div className="container mb-24 pb-5 h-full">
+									{/* Page Contents here */}
+									{children}
 								</div>
-							</header>
-							<TopSearchBar
-								searchResults={searchResults}
-								searchQuery={searchQuery}
-								modalIsOpen={modalIsOpen}
-								closeModal={closeModal}
-								clearSearchQuery={clearSearchQuery}
-								handleSearchChange={handleSearchChange}
-							/>
+							</main>
 						</div>
 
-						<main className="h-full main flex flex-col flex-grow transition-all duration-150 ease-in">
-							<div className="container mb-24 pb-5 h-full">
-								{/* Page Contents here */}
-								{children}
-							</div>
-						</main>
+						<Footer />
 					</div>
-
-					<Footer />
 				</div>
 			</div>
-		</div>
+		</DarkModeCtx.Provider>
 	);
 };
 

--- a/web/src/components/Structure/MenuItem.tsx
+++ b/web/src/components/Structure/MenuItem.tsx
@@ -3,15 +3,16 @@ import { FC } from "react";
 interface MenuItemProps {
     name: string;
     icon: JSX.Element;
-    href: string;
+    href: string | null;
 }
 const MenuItem: FC<MenuItemProps> = ({ name, icon, href, ...props }) => (
     <li className="my-px" {...props}>
         <a
-            href={href}
-            className="flex flex-row items-center h-10 px-3 rounded-lg text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            href={href == null ? void 0 : href}
+            className="flex flex-row items-center h-10 px-3 rounded-lg text-contrast-600
+                hover:bg-contrast-400 hover:text-contrast-700 cursor-pointer"
         >
-            <span className="flex items-center justify-center text-lg text-gray-400">
+            <span className="flex items-center justify-center text-lg">
                 {icon}
             </span>
             <span className="ml-3">{name}</span>

--- a/web/src/components/Structure/SideBar.tsx
+++ b/web/src/components/Structure/SideBar.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { User } from "../../types";
+import Image from "next/image";
+import MenuItem from "./MenuItem";
+import { FiArchive, FiBookOpen, FiHome, FiLogIn, FiLogOut, FiUser, FiUsers } from "react-icons/fi";
+import { AiOutlineMail, AiOutlinePlusCircle } from "react-icons/ai";
+import { MdLibraryBooks } from "react-icons/md";
+import { FaLightbulb, FaRegLightbulb } from "react-icons/fa";
+import { useDarkMode } from "../../hooks/use-dark-mode";
+
+export const SideBar: React.FC<{
+	authenticated: boolean,
+	user?: User
+}> = ({ authenticated, user }) => {
+	const { dark, setDark } = useDarkMode();
+
+	return (
+		<aside
+			className="sidebar w-64 shadow transform -translate-x-full md:translate-x-0 transition-transform hidden md:block duration-150 ease-in z-10 bg-contrast-300">
+			<div className="sidebar-header flex items-center justify-center py-4">
+				<div className="inline-flex">
+					<a
+						href="/"
+						className="inline-flex flex-row items-center"
+					>
+						<Image
+							src="/book.png"
+							alt="TMW"
+							width={40}
+							height={40}
+						/>
+					</a>
+				</div>
+			</div>
+			<nav className="sidebar-content px-4 py-6 sticky top-0">
+				<ul className="flex flex-col w-full">
+					<li className="my-px">
+					<span className="flex font-medium text-sm text-contrast-700 px-4 my-4 uppercase">
+						Wiki
+					</span>
+					</li>
+					<MenuItem name="Home" href="/" icon={<FiHome/>}/>
+					<MenuItem
+						name="Articles"
+						href="/articles"
+						icon={<FiBookOpen/>}
+					/>
+					<MenuItem
+						name="New Article"
+						href="/article/new"
+						icon={<AiOutlinePlusCircle/>}
+					/>
+					<MenuItem
+						name="Archive"
+						href="/archive"
+						icon={<FiArchive/>}
+					/>
+
+					<li className="my-px">
+					<span className="flex font-medium text-sm text-contrast-700 px-4 my-4 uppercase">
+						Account
+					</span>
+					</li>
+
+					{authenticated ? (
+						<>
+							<MenuItem
+								name="Profile"
+								href="/profile/@me"
+								icon={<FiUser/>}
+							/>
+							<MenuItem
+								name="Logout"
+								href="/api/auth/logout"
+								icon={<FiLogOut color="#ff4843"/>}
+							/>
+						</>
+					) : (
+						<MenuItem
+							name="Login"
+							href="/api/auth/login"
+							icon={<FiLogIn color="#29b84c"/>}
+						/>
+					)}
+
+					{user && user?.rank > 4 ? (
+						<>
+							<li className="my-px">
+							<span className="flex font-medium text-sm text-contrast-700 px-4 my-4 uppercase">
+								Admin
+							</span>
+							</li>
+							<MenuItem
+								name="Articles"
+								href="/admin/articles"
+								icon={<MdLibraryBooks/>}
+							/>
+							<MenuItem
+								name="Users"
+								href="/admin/users"
+								icon={<FiUsers/>}
+							/>
+							<MenuItem
+								name="Message Discord"
+								href="/admin/message"
+								icon={<AiOutlineMail/>}
+							/>
+						</>
+					) : null}
+
+					<li className="my-px">
+					<span className="flex font-medium text-sm text-contrast-700 px-4 my-4 uppercase">
+						UI
+					</span>
+					</li>
+					<span onClick={() => setDark(!dark)}>
+						<MenuItem
+							name={`${dark ? "Light" : "Dark"} Mode`}
+							href={null}
+							icon={dark ? <FaLightbulb/> : <FaRegLightbulb/>}
+						/>
+					</span>
+				</ul>
+			</nav>
+		</aside>
+	);
+}

--- a/web/src/components/Structure/SideBar.tsx
+++ b/web/src/components/Structure/SideBar.tsx
@@ -16,7 +16,8 @@ export const SideBar: React.FC<{
 
 	return (
 		<aside
-			className="sidebar w-64 shadow transform -translate-x-full md:translate-x-0 transition-transform hidden md:block duration-150 ease-in z-10 bg-contrast-300">
+			className="sidebar w-64 shadow-sidebar-custom transform -translate-x-full md:translate-x-0 transition-transform hidden
+				md:block duration-150 ease-in z-10 bg-contrast-300">
 			<div className="sidebar-header flex items-center justify-center py-4">
 				<div className="inline-flex">
 					<a

--- a/web/src/hooks/use-dark-mode.ts
+++ b/web/src/hooks/use-dark-mode.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from "react";
+
+export const DarkModeCtx = createContext<{
+	dark: boolean,
+	setDark(dark: boolean): void
+}>(null as any);
+
+export const useDarkMode = () => useContext(DarkModeCtx);

--- a/web/src/pages/about.tsx
+++ b/web/src/pages/about.tsx
@@ -61,7 +61,7 @@ const About: NextPage = () => (
         <h1 className="text-2xl w-full text-center">Mission</h1>
         <hr className="dividing-line" />
         <p className="mt-5">
-            The mission for the Technical Minecraft Wiki is to gather everyone's
+            The mission for the Technical Minecraft Wiki is to gather everyone&apos;s
             information into one spot. We believe this will significantly better
             the community by making it easier for new players to start exploring
             the world of technical minecraft.
@@ -91,7 +91,7 @@ const About: NextPage = () => (
             like to contribute.
         </p>
         <p className="mt-5">
-            The site is run completely out of Jakku's pocket and although he is
+            The site is run completely out of Jakku&apos;s pocket and although he is
             glad to run it, donations are greatly appreciated and can be donated
             to him through his{" "}
             <u>

--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -50,7 +50,7 @@ const Index = () => (
                 }}
             />
         </Head>
-        <div className="flex flex-column flex-wrap items-center rounded border p-5 mb-5">
+        <div className="flex flex-column flex-wrap items-center rounded-lg border border-contrast-400 p-5 mb-5">
             <div className="flex w-full">
                 <h1 className="w-full text-xl">
                     Welcome to the Technical Minecraft Wiki!

--- a/web/src/pages/style-guide.tsx
+++ b/web/src/pages/style-guide.tsx
@@ -20,7 +20,7 @@ const StyleGuide: NextPage = () => (
             this page always has precedence over its subpages and the Wikipedia
             style guide.
         </p>
-        <div className="border p-5 my-5 w-min bg-gray-50 whitespace-nowrap">
+        <div className="border border-contrast-400 rounded-lg bg-[#f9fafB] dark:bg-[#333333] p-5 my-5 w-min whitespace-nowrap">
             <h4>Document Outline</h4>
             <ul className="ml-5">
                 <li>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -208,30 +208,26 @@
     }
 }
 
+/*
+ Lower contrast numbers should be used
+ for background while higher numbers should be
+ used for text, and basically for things you
+ want the user to see.
+ */
 html:root {
-    --cl-contrast-0: white;
-    --cl-contrast-50: "#fafafa";
-    --cl-contrast-100: "#f5f5f5";
-    --cl-contrast-200: "#e5e5e5";
-    --cl-contrast-300: "#d4d4d4";
-    --cl-contrast-400: "#a3a3a3";
-    --cl-contrast-500: "#737373";
-    --cl-contrast-600: "#525252";
-    --cl-contrast-700: "#404040";
-    --cl-contrast-800: "#262626";
-    --cl-contrast-900: "#171717";
+    --cl-contrast-300: white;
+    --cl-contrast-400: #d2d2d2;
+    --cl-contrast-500: #ababab;
+    --cl-contrast-600: #6c6c6c;
+    --cl-contrast-700: #3d3d3d;
+    --cl-contrast-800: #1c1c1c;
 }
 
 html.dark:root {
-    --cl-contrast-0: black;
-    --cl-contrast-50: "#171717";
-    --cl-contrast-100: "#262626";
-    --cl-contrast-200: "#404040";
-    --cl-contrast-300: "#525252";
-    --cl-contrast-400: "#737373";
-    --cl-contrast-500: "#a3a3a3";
-    --cl-contrast-600: "#d4d4d4";
-    --cl-contrast-700: "#e5e5e5";
-    --cl-contrast-800: "#f5f5f5";
-    --cl-contrast-900: "#fafafa";
+    --cl-contrast-300: #2b2b2b;
+    --cl-contrast-400: #404040;
+    --cl-contrast-500: #535353;
+    --cl-contrast-600: #888585;
+    --cl-contrast-700: #a7a7a7;
+    --cl-contrast-800: #ededed;
 }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -208,6 +208,16 @@
     }
 }
 
+html {
+    transition: background-color,
+                color,
+                border-top-color,
+                border-bottom-color,
+                border-left-color,
+                border-right-color,
+                outline-color        ease 1s;
+}
+
 /*
  Lower contrast numbers should be used
  for background while higher numbers should be
@@ -215,19 +225,19 @@
  want the user to see.
  */
 html:root {
-    --cl-contrast-300: white;
-    --cl-contrast-400: #d2d2d2;
-    --cl-contrast-500: #ababab;
-    --cl-contrast-600: #6c6c6c;
-    --cl-contrast-700: #3d3d3d;
-    --cl-contrast-800: #1c1c1c;
+    --cl-contrast-300: 255, 255, 255;
+    --cl-contrast-400: 210, 210, 210;
+    --cl-contrast-500: 171, 171, 171;
+    --cl-contrast-600: 108, 108, 108;
+    --cl-contrast-700: 61, 61, 61;
+    --cl-contrast-800: 28, 28, 28;
 }
 
 html.dark:root {
-    --cl-contrast-300: #2b2b2b;
-    --cl-contrast-400: #404040;
-    --cl-contrast-500: #535353;
-    --cl-contrast-600: #888585;
-    --cl-contrast-700: #a7a7a7;
-    --cl-contrast-800: #ededed;
+    --cl-contrast-300: 43, 43, 43;
+    --cl-contrast-400: 64, 64, 64;
+    --cl-contrast-500: 83, 83, 83;
+    --cl-contrast-600: 136, 133, 133;
+    --cl-contrast-700: 167, 167, 167;
+    --cl-contrast-800: 237, 237, 237;
 }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -207,3 +207,31 @@
         transform: translate(24px, 0);
     }
 }
+
+html:root {
+    --cl-contrast-0: white;
+    --cl-contrast-50: "#fafafa";
+    --cl-contrast-100: "#f5f5f5";
+    --cl-contrast-200: "#e5e5e5";
+    --cl-contrast-300: "#d4d4d4";
+    --cl-contrast-400: "#a3a3a3";
+    --cl-contrast-500: "#737373";
+    --cl-contrast-600: "#525252";
+    --cl-contrast-700: "#404040";
+    --cl-contrast-800: "#262626";
+    --cl-contrast-900: "#171717";
+}
+
+html.dark:root {
+    --cl-contrast-0: black;
+    --cl-contrast-50: "#171717";
+    --cl-contrast-100: "#262626";
+    --cl-contrast-200: "#404040";
+    --cl-contrast-300: "#525252";
+    --cl-contrast-400: "#737373";
+    --cl-contrast-500: "#a3a3a3";
+    --cl-contrast-600: "#d4d4d4";
+    --cl-contrast-700: "#e5e5e5";
+    --cl-contrast-800: "#f5f5f5";
+    --cl-contrast-900: "#fafafa";
+}

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -12,10 +12,16 @@ module.exports = {
 					// light mode: white -> black
 					// dark mode:  black -> white
 					[ 300, 400, 500, 600, 700, 800, 900
-					].map(n => [n, `var(--cl-contrast-${n})`])
+					].map(n => [n, `rgb(var(--cl-contrast-${n}))`])
 				)
+			},
+			boxShadow: {
+				// there is no way to change the color of the shadow using taiwind:
+				// https://github.com/tailwindlabs/tailwindcss/issues/654
+				"sidebar-custom":
+					"0 1px 3px 0 rgba(var(--cl-contrast-800), 0.1), 0 1px 2px 0 rgba(var(--cl-contrast-800), 0.06)"
 			}
-		},
+		}
 	},
 	variants: {
 		extend: {},

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,12 +1,23 @@
+const colors = require("tailwindcss/colors");
+
 module.exports = {
-  purge: ["./src/**/*.tsx", "./public/index.html"], 
-  // purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
-  darkMode: false, // or 'media' or 'class'
-  theme: {
-    extend: {},
-  },
-  variants: {
-    extend: {},
-  },
-  plugins: [],
+	purge: [ "./src/**/*.tsx", "./public/index.html" ],
+	darkMode: "class",
+	theme: {
+		extend: {
+			gray: colors.trueGray,
+			colors: {
+				contrast: Object.fromEntries(
+					// light mode: white -> black
+					// dark mode:  black -> white
+					[ 0, 50, 100, 200, 300, 400, 500, 600, 800, 900
+					].map(n => [n, `var(--cl-contrast-${n})`])
+				)
+			}
+		},
+	},
+	variants: {
+		extend: {},
+	},
+	plugins: [],
 }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,7 +1,8 @@
 const colors = require("tailwindcss/colors");
 
 module.exports = {
-	purge: [ "./src/**/*.tsx", "./public/index.html" ],
+	mode: "jit",
+	purge: [ "./src/**/*.{tsx,ts}", "./public/index.html" ],
 	darkMode: "class",
 	theme: {
 		extend: {
@@ -10,7 +11,7 @@ module.exports = {
 				contrast: Object.fromEntries(
 					// light mode: white -> black
 					// dark mode:  black -> white
-					[ 0, 50, 100, 200, 300, 400, 500, 600, 800, 900
+					[ 300, 400, 500, 600, 700, 800, 900
 					].map(n => [n, `var(--cl-contrast-${n})`])
 				)
 			}


### PR DESCRIPTION
## Dark mode
* Tailwind offers dark mode by adding another class prefixed with `dark:`. This can quickly become bothersome. Instead, we use a Tailwind color named `contrast`, that is basically a CSS variable that will change depending on the theme.
They range from value 300 and 800: lower numbers should be used for background things and higher numbers for text and things you want the user to see.
That means instead of using `text-gray-300` you'll use `text-contrast-700`. You can still use `dark:` for custom colors though.
I've only converted the Sidebar and the main Layout component, but you can see what I mean by looking at the changes.

* If you want to change the colors, change them at `web/src/styles/global.css`. I used the same as [TMA's](https://github.com/samipourquoi/tma/blob/main/packages/othello/src/styles/index.scss).

* To toggle Dark mode, I've added a button to the sidebar that does that. You probably want to change it to something else.

* The theme preference is saved in local storage, it would be best if it was saved in the cookies (or somewhere else) so that the server can pre-render it and avoid a flicker when loading the page.

## CSS bugs
I don't really remember what I did because that was a few weeks ago lol.
There are these weird bumps on the line separating the sidebar and the main content that I fixed though.

## Tailwind JIT
I switched to [Tailwind JIT](https://tailwindcss.com/docs/just-in-time-mode), but that doesn't change much to the code.
